### PR TITLE
Updated opencsv dependency, fixed depending code.

### DIFF
--- a/arff/src/main/java/org/apache/metamodel/arff/ArffDataSet.java
+++ b/arff/src/main/java/org/apache/metamodel/arff/ArffDataSet.java
@@ -35,12 +35,12 @@ import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.util.NumberComparator;
 import org.apache.metamodel.util.Resource;
 
-import com.opencsv.CSVParser;
+import com.opencsv.CSVParserBuilder;
 import com.opencsv.ICSVParser;
 
 final class ArffDataSet extends AbstractDataSet {
 
-    private final ICSVParser csvParser = new CSVParser(',', '\'');
+    private final ICSVParser csvParser =  new CSVParserBuilder().withSeparator(',') .withQuoteChar('\'').build();
     private final Resource resource;
     private final BufferedReader reader;
     private final List<Column> columns;

--- a/csv/src/main/java/org/apache/metamodel/csv/CsvDataContext.java
+++ b/csv/src/main/java/org/apache/metamodel/csv/CsvDataContext.java
@@ -49,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
 import com.opencsv.ICSVParser;
 
 /**
@@ -306,11 +307,11 @@ public final class CsvDataContext extends QueryPostprocessDataContext implements
 
     protected CSVReader createCsvReader(int skipLines) {
         final Reader reader = FileHelper.getReader(_resource.read(), _configuration.getEncoding());
-        return new CSVReader(reader, skipLines, createParser());
+        return new CSVReaderBuilder(reader).withSkipLines(skipLines).withCSVParser(createParser()).build();
     }
 
     protected CSVReader createCsvReader(BufferedReader reader) {
-        return new CSVReader(reader, CSVReader.DEFAULT_SKIP_LINES, createParser());
+        return new CSVReaderBuilder(reader).withCSVParser(createParser()).build();
     }
 
     @Override

--- a/csv/src/main/java/org/apache/metamodel/csv/CsvDataSet.java
+++ b/csv/src/main/java/org/apache/metamodel/csv/CsvDataSet.java
@@ -31,6 +31,7 @@ import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.util.FileHelper;
 
 import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 
 /**
  * Streaming DataSet implementation for CSV support
@@ -91,7 +92,7 @@ final class CsvDataSet extends AbstractDataSet {
         final String[] csvValues;
         try {
             csvValues = _reader.readNext();
-        } catch (IOException e) {
+        } catch (IOException | CsvValidationException e) {
             throw new IllegalStateException("Exception reading from file", e);
         }
         if (csvValues == null) {

--- a/csv/src/main/java/org/apache/metamodel/csv/CsvTable.java
+++ b/csv/src/main/java/org/apache/metamodel/csv/CsvTable.java
@@ -42,6 +42,7 @@ import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.LegacyDeserializationObjectInputStream;
 
 import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 
 final class CsvTable extends AbstractTable {
 
@@ -108,7 +109,7 @@ final class CsvTable extends AbstractTable {
 
             reader.close();
             return buildColumns(columnHeaders);
-        } catch (IOException e) {
+        } catch (IOException | CsvValidationException e) {
             throw new IllegalStateException("Exception reading from resource: "
                     + _schema.getDataContext().getResource().getName(), e);
         } finally {

--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@ under the License.
 			<dependency>
 				<groupId>com.opencsv</groupId>
 				<artifactId>opencsv</artifactId>
-				<version>3.9</version>
+				<version>5.5.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
**Motivation**
I'm working on a product that depends on the original Apache metamodel as well as opencsv. We'd like to update our opencsv dependency to the latest version without breaking metamodel. Furthermore, we'd like to replace our metamodel dependency with a release artefact from the datacleaner fork soon.

**Contents**
- The opencsv version has been bumped in the root POM
- New checked CsvValidationException is caught
- CSVReader is constructed through the new CSVReaderBuilder

Greetings from netgo Software Berlin!